### PR TITLE
Update to bootstrap 5.3.7

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="assets/favicon.ico" />
     <title>GitHub Actions Workflow Generator for MATLAB</title>
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css"
       rel="stylesheet" />
     <link href="style.css" rel="stylesheet" />
   </head>
@@ -189,7 +189,7 @@
         The MathWorks, Inc.
       </p>
     </footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
     <script type="module" src="scripts/main.js"></script>
     <script>


### PR DESCRIPTION
Bootstrap 5.3.7 makes the toggle switches slightly darker. 

If they're still not dark enough, we can consider customizing them more but I prefer to keep the default styling if possible because it has gone through a number of reviews and there are many details to consider when you start to touch the color palette. 

Closes #4 